### PR TITLE
Fix borrow functionality

### DIFF
--- a/components/MenuDrawer.js
+++ b/components/MenuDrawer.js
@@ -1,21 +1,27 @@
-import React, { Component } from 'react';
-import {StyleSheet, View, Text, TouchableOpacity, Image} from 'react-native';
-import Drawer from 'react-native-drawer';
-import MenuItems from './MenuItems';
-import { withNavigation } from 'react-navigation';
-import menu from '../assets/images/menuicon.png';
-import menuClosed from '../assets/images/X.png';
+import React, { Component } from "react";
+import { StyleSheet, View, Text, TouchableOpacity, Image } from "react-native";
+import Drawer from "react-native-drawer";
+import MenuItems from "./MenuItems";
+import { withNavigation } from "react-navigation";
+import menu from "../assets/images/menuicon.png";
+import menuClosed from "../assets/images/X.png";
 
 export default class MenuDrawer extends Component {
   constructor() {
-    super()
-    this.state={ menuOpen: false }
+    super();
+    this.state = { menuOpen: false };
   }
+
+  closeMenu = () => {
+    this.setState({ menuOpen: false });
+  };
 
   render() {
     return (
       <View style={styles.drawerContainer}>
-        <TouchableOpacity onPress={() => this.setState({menuOpen: !this.state.menuOpen})}>
+        <TouchableOpacity
+          onPress={() => this.setState({ menuOpen: !this.state.menuOpen })}
+        >
           <Image
             source={this.state.menuOpen ? menuClosed : menu}
             style={styles.menu}
@@ -26,29 +32,33 @@ export default class MenuDrawer extends Component {
           type="static"
           openDrawerOffset={0.5}
           closedDrawerOffset={0}
-          content={this.state.menuOpen ? <MenuItems /> : null}
+          content={
+            this.state.menuOpen ? (
+              <MenuItems closeMenu={this.closeMenu} />
+            ) : null
+          }
           tapToClose={true}
           onClose={this.closeDrawer}
           styles={styles.drawer}
-          tweenEasing={'easeInOutQuad'}
+          tweenEasing={"easeInOutQuad"}
           tweenDuration={400}
         ></Drawer>
       </View>
-    )
+    );
   }
 }
 
 const styles = StyleSheet.create({
   drawerContainer: {
-    width: '190%',
+    width: "190%"
   },
   drawer: {
-    backgroundColor: '#fff',
+    backgroundColor: "#fff"
   },
   menu: {
     height: 30,
     margin: 20,
     marginTop: 23,
-    width: 40,
-  },
+    width: 40
+  }
 });

--- a/components/MenuItems.js
+++ b/components/MenuItems.js
@@ -3,21 +3,26 @@ import { StyleSheet, View, Text, TouchableOpacity, Image } from "react-native";
 import Colors from "../constants/Colors";
 import { useNavigation } from "@react-navigation/native";
 
-export default function MenuItems() {
+export default function MenuItems({ closeMenu }) {
   const navigation = useNavigation();
+
+  const handlePress = path => {
+    navigation.navigate(path);
+    closeMenu();
+  };
 
   return (
     <View style={styles.drawerItems}>
-      <TouchableOpacity onPress={() => navigation.navigate("Home")}>
+      <TouchableOpacity onPress={() => handlePress("Home")}>
         <Text style={styles.drawerText}>Go to Lending</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("My Items")}>
+      <TouchableOpacity onPress={() => handlePress("My Items")}>
         <Text style={styles.drawerText}>View My Borrowed Items</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("RequestScreen")}>
+      <TouchableOpacity onPress={() => handlePress("RequestScreen")}>
         <Text style={styles.drawerText}>Make A Request</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("Home")}>
+      <TouchableOpacity onPress={() => handlePress("Home")}>
         <Text style={styles.drawerText}>Logout</Text>
       </TouchableOpacity>
     </View>

--- a/components/SearchResultsContainer.js
+++ b/components/SearchResultsContainer.js
@@ -33,7 +33,9 @@ export function SearchResultsContainer(props) {
       }
     `;
 
-  const { loading, error, data } = useQuery(ITEMS);
+  const { loading, error, data } = useQuery(ITEMS, {
+    fetchPolicy: "network-only"
+  });
 
   if (loading) return <Text style={styles.loadingText}>Loading...</Text>;
   if (error) return <Text style={styles.errorText}>No items found!</Text>;

--- a/components/SearchResultsContainer.js
+++ b/components/SearchResultsContainer.js
@@ -12,11 +12,13 @@ import Colors from "../constants/Colors";
 import { gql } from "apollo-boost";
 import { useQuery } from "@apollo/react-hooks";
 
+export let ITEMS;
+
 export function SearchResultsContainer(props) {
   let category = props.items.category;
   let item = props.items.itemName;
 
-  const ITEMS = gql`
+  ITEMS = gql`
       {
         getAllItemsByName(name: "${category}", items: "${item}") {
           name
@@ -33,7 +35,7 @@ export function SearchResultsContainer(props) {
       }
     `;
 
-  const { loading, error, data } = useQuery(ITEMS, {
+  let { loading, error, data } = useQuery(ITEMS, {
     fetchPolicy: "network-only"
   });
 
@@ -50,7 +52,7 @@ export function SearchResultsContainer(props) {
           <Text style={styles.resultsText}>Results:</Text>
           {data.getAllItemsByName.length ? (
             data.getAllItemsByName.map(item => (
-              <SearchResult key={item.name} item={item} />
+              <SearchResult key={item.id} item={item} />
             ))
           ) : (
             <Text style={styles.errorText}>No items found!</Text>

--- a/screens/ItemDetailsScreen.js
+++ b/screens/ItemDetailsScreen.js
@@ -1,14 +1,17 @@
-import * as WebBrowser from 'expo-web-browser';
-import * as React from 'react';
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
-import Colors from '../constants/Colors';
+import * as WebBrowser from "expo-web-browser";
+import * as React from "react";
+import { StyleSheet, Text, View, TouchableOpacity } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import Colors from "../constants/Colors";
+import { ITEMS } from "../components/SearchResultsContainer";
 
 import { gql } from "apollo-boost";
 import { useMutation } from "@apollo/react-hooks";
 
 export default function ItemDetailsScreen(props) {
   const item = props.route.params.item;
+
+  const [status, setStatus] = React.useState(true);
 
   const UPDATE_ITEM = gql`
     mutation {
@@ -22,7 +25,31 @@ export default function ItemDetailsScreen(props) {
     }
   `;
 
-  const [updateItem] = useMutation(UPDATE_ITEM);
+  const handleBorrow = () => {
+    updateItem()
+      .then(() => setStatus(!item.available))
+      .then(() =>
+        props.navigation.navigate("Success!", {
+          action: "reserved",
+          name: item.name,
+          quantity: item.quantity,
+          measurement: item.measurement,
+          timeDuration: item.timeDuration
+        })
+      );
+  };
+
+  const [updateItem] = useMutation(UPDATE_ITEM, {
+    refetchQueries: () => [
+      {
+        query: ITEMS,
+        variables: {
+          name: item.category.name,
+          items: item.name
+        }
+      }
+    ]
+  });
 
   return (
     <ScrollView
@@ -34,7 +61,7 @@ export default function ItemDetailsScreen(props) {
       </Text>
       <View style={styles.infoContainer}>
         <Text style={styles.itemInfoTitle}>Status:</Text>
-        {item.available ? (
+        {status && item.available ? (
           !item.timeDuration ? (
             <Text style={styles.itemInfo}>
               {item.quantity} {item.measurement ? item.measurement : ""}{" "}
@@ -52,22 +79,13 @@ export default function ItemDetailsScreen(props) {
         <Text style={styles.itemInfo}>{item.category.name}</Text>
         <Text style={styles.itemInfoTitle}>Description:</Text>
         <Text style={styles.itemInfo}>
-          {item.description || 'No description yet!'}
+          {item.description || "No description yet!"}
         </Text>
       </View>
-      {item.available ? (
+      {status && item.available ? (
         <TouchableOpacity
           style={styles.borrowButton}
-          onPress={() =>
-            updateItem() &&
-            props.navigation.navigate("Success!", {
-              action: "reserved",
-              name: item.name,
-              quantity: item.quantity,
-              measurement: item.measurement,
-              timeDuration: item.timeDuration
-            })
-          }
+          onPress={() => handleBorrow()}
         >
           <Text style={styles.borrowButtonText}>Borrow this Item</Text>
         </TouchableOpacity>
@@ -85,15 +103,15 @@ export default function ItemDetailsScreen(props) {
 
 const styles = StyleSheet.create({
   container: {
-    alignContent: 'center',
-    backgroundColor: '#fafafa',
+    alignContent: "center",
+    backgroundColor: "#fafafa",
     flex: 1,
-    textAlign: 'center',
+    textAlign: "center"
   },
   contentContainer: {
-    justifyContent: 'center',
+    justifyContent: "center",
     padding: 15,
-    paddingTop: 50,
+    paddingTop: 50
   },
   borrowButton: {
     marginRight: 40,
@@ -104,35 +122,35 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.lightBlue,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#fff',
+    borderColor: "#fff"
   },
   borrowButtonText: {
     fontSize: 25,
-    fontWeight: 'bold',
-    color: '#fff',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "#fff",
+    textAlign: "center"
   },
   name: {
-    alignSelf: 'center',
+    alignSelf: "center",
     backgroundColor: Colors.aqua,
     fontSize: 35,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     height: 60,
     marginBottom: 25,
     paddingTop: 8,
-    textAlign: 'center',
-    width: '100%',
+    textAlign: "center",
+    width: "100%"
   },
   infoContainer: {
-    alignSelf: 'center',
+    alignSelf: "center"
   },
   itemInfo: {
     fontSize: 25,
-    marginBottom: 15,
+    marginBottom: 15
   },
   itemInfoTitle: {
     fontSize: 25,
-    fontWeight: 'bold',
-    marginTop: 10,
-  },
+    fontWeight: "bold",
+    marginTop: 10
+  }
 });

--- a/screens/ItemDetailsScreen.js
+++ b/screens/ItemDetailsScreen.js
@@ -13,7 +13,7 @@ export default function ItemDetailsScreen(props) {
   const UPDATE_ITEM = gql`
     mutation {
       item: updateItemAvailability(
-        input: { id: 3, available: true, name: "trowel" }
+        input: { id: ${item.id}, available: ${item.available}, name: "${item.name}" }
       ) {
         id
         available

--- a/screens/MyItemsScreen.js
+++ b/screens/MyItemsScreen.js
@@ -21,7 +21,7 @@ export default function MyItemsScreen(props) {
   const UPDATE_ITEM = gql`
     mutation {
       item: updateItemAvailability(
-        input: { id: 3, available: false, name: "trowel" }
+        input: { id: 23, available: false, name: "trowel" }
       ) {
         id
         available
@@ -34,7 +34,7 @@ export default function MyItemsScreen(props) {
 
   const item = {
     name: "trowel",
-    quantity: 3,
+    quantity: 23,
     measurement: null,
     timeDuration: "weeks"
   };
@@ -44,7 +44,7 @@ export default function MyItemsScreen(props) {
       <Text style={styles.itemsMessage}>You are currently borrowing:</Text>
       <ScrollView style={styles.itemsContainer}>
         <View style={styles.item}>
-          <Text style={styles.itemName}>Butter</Text>
+          <Text style={styles.itemName}>Trowel</Text>
           <TouchableOpacity
             style={styles.returnButton}
             onPress={() => {

--- a/screens/SearchResultsScreen.js
+++ b/screens/SearchResultsScreen.js
@@ -11,10 +11,8 @@ import {
 } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import Colors from "../constants/Colors";
-import { useNavigation } from "@react-navigation/native";
 
 export default function SearchResultsScreen(props) {
-  const navigation = useNavigation();
   const category = props.route.params.category;
   const itemName = props.route.params.itemName;
 

--- a/screens/SearchResultsScreen.js
+++ b/screens/SearchResultsScreen.js
@@ -23,7 +23,7 @@ export default function SearchResultsScreen(props) {
     >
       <TouchableOpacity
         style={styles.searchButton}
-        onPress={() => navigation.navigate("Home")}
+        onPress={() => props.navigation.navigate("Home")}
       >
         <Text style={styles.searchButtonText}>Try Another Search</Text>
       </TouchableOpacity>

--- a/screens/SuccessfulBorrowScreen.js
+++ b/screens/SuccessfulBorrowScreen.js
@@ -24,7 +24,7 @@ export default function SuccessfulBorrowScreen(props) {
       <Text style={styles.successMessage}>You have successfully {action}:</Text>
       {!timeDuration ? (
         <Text style={styles.itemInfo}>
-          {quantity} {measurement + " of"} {name} )
+          {quantity} {measurement + " of"} {name}
         </Text>
       ) : (
         <Text style={styles.itemInfo}>


### PR DESCRIPTION
# What does this PR do?
- Closes the dropdown menu when you navigate to a new screen so that it is not still open if you navigate back
- Updates the dom to reflect an item's changed availability status. If you borrow an item and navigate backwards, the item will be marked as not available. If you borrow an item and search for that item again, the item will be marked as not aailable
- Replaces hard coded data in borrow mutation with variables 
- Fixes some broken navigation links

# Where should your reviewer start?
ItemDetailsScreen

# What are the related issues?
#18 #17 

# Anything else your reviewer should know?
The user's items are still hard coded in. I'm still using "trowel" as my test item.

